### PR TITLE
Add support for `magento/magento-composer-installer` to automate LESS file mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,6 @@
         <pre><code>php bin/magento cache:flush</code></pre>
     </li>
 </ol>
-<h4>Cloud environment</h4>
-<p>
-    In the Magento Cloud environment, the file system is read-only. 
-    Therefore, you need to manually replace the file 
-    <code>[magento-root-folder]/lib/web/css/source/lib/_responsive.less</code> 
-    with the one provided by the module: 
-    <code>[Amasty_Mage248Fix]/lib/web/css/source/lib/_responsive.less</code>, 
-    before pushing your changes to the branch.
-</p>
 
 <h2>Requirenements</h2>
 <p>This module require:</p>

--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,13 @@
         "psr-4": {
             "Amasty\\Mage248Fix\\": ""
         }
+    },
+    "extra": {
+        "map": [
+            [
+                "lib/web/css",
+                "lib/web/css"
+            ]
+        ]
     }
 }


### PR DESCRIPTION
### Add support for `magento/magento-composer-installer` to automate LESS file mapping

#### Summary
This PR adds support for the `magento/magento-composer-installer` Composer plugin to automatically handle LESS file mapping, removing the need for manual file copying.

#### Details
- Added the `extra/map` configuration to `composer.json` to ensure LESS files are copied automatically during installation.  
- This improvement eliminates the manual step previously required to move LESS assets.  
- The implementation works seamlessly for both **Magento 2 Open Source** and **Magento Cloud** environments.

#### References
- [magento/magento-composer-installer usage documentation](https://github.com/magento/magento-composer-installer?tab=readme-ov-file#usage)

#### Testing
1. Install the module via Composer.  
2. Verify that the LESS files are automatically copied to the appropriate location.  
3. Confirm no manual file operations are needed post-installation.
