### PR TITLE
Update `magento/framework` dependency for `2.4.8-p4` patch compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,22 +1,22 @@
 {
-    "name": "amasty/module-mage-248-fix",
-    "description": "Fix several issues on Magento 2.4.8 version by Amasty",
-    "require": {
-        "php": ">=8.1",
-        "amasty/base": ">=1.21.1",
-        "magento/framework": "~103.0.8.0",
-        "wikimedia/less.php": "^5.3.1"
-    },
-    "homepage": "https://amasty.com/",
-    "type": "magento2-module",
-    "version": "1.0.6",
-    "license": "proprietary",
-    "autoload": {
-        "files": [
-            "registration.php"
-        ],
-        "psr-4": {
-            "Amasty\\Mage248Fix\\": ""
-        }
+  "name": "amasty/module-mage-248-fix",
+  "description": "Fix several issues on Magento 2.4.8 version by Amasty",
+  "require": {
+    "php": ">=8.1",
+    "amasty/base": ">=1.21.1",
+    "magento/framework": ">=103.0.8-p1 <103.1.0",
+    "wikimedia/less.php": "^5.3.1"
+  },
+  "homepage": "https://amasty.com/",
+  "type": "magento2-module",
+  "version": "1.0.6",
+  "license": "proprietary",
+  "autoload": {
+    "files": [
+      "registration.php"
+    ],
+    "psr-4": {
+      "Amasty\\Mage248Fix\\": ""
     }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,22 +1,22 @@
 {
-  "name": "amasty/module-mage-248-fix",
-  "description": "Fix several issues on Magento 2.4.8 version by Amasty",
-  "require": {
-    "php": ">=8.1",
-    "amasty/base": ">=1.21.1",
-    "magento/framework": ">=103.0.8-p1 <103.1.0",
-    "wikimedia/less.php": "^5.3.1"
-  },
-  "homepage": "https://amasty.com/",
-  "type": "magento2-module",
-  "version": "1.0.6",
-  "license": "proprietary",
-  "autoload": {
-    "files": [
-      "registration.php"
-    ],
-    "psr-4": {
-      "Amasty\\Mage248Fix\\": ""
+    "name": "amasty/module-mage-248-fix",
+    "description": "Fix several issues on Magento 2.4.8 version by Amasty",
+    "require": {
+        "php": ">=8.1",
+        "amasty/base": ">=1.21.1",
+        "magento/framework": ">=103.0.8-p1 <103.1.0",
+        "wikimedia/less.php": "^5.3.1"
+    },
+    "homepage": "https://amasty.com/",
+    "type": "magento2-module",
+    "version": "1.0.6",
+    "license": "proprietary",
+    "autoload": {
+        "files": [
+            "registration.php"
+        ],
+        "psr-4": {
+            "Amasty\\Mage248Fix\\": ""
+        }
     }
-  }
 }


### PR DESCRIPTION
This PR updates the `magento/framework` dependency to allow installation of the `Magento Open Source 2.4.8-p4` patch.

- Problem: The previous version of `magento/framework` was too restrictive and blocked the patch installation.
- Solution: Updated the `magento/framework` version to `103.0.8-p4`, which is required by the patch.

This change ensures the project can integrate the latest security fixes and improvements from Magento.